### PR TITLE
fix(dependencies) make chokidar optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-copy-source",
-  "version": "2.0.9",
+  "version": "3.0.0",
   "description": "Script to copy javascript files and append \".flow\" to the filename.",
   "main": "src/index.js",
   "bin": {
@@ -31,11 +31,13 @@
   },
   "homepage": "https://github.com/Macil/flow-copy-source#readme",
   "dependencies": {
-    "chokidar": "^3.0.0",
     "fs-extra": "^8.1.0",
     "glob": "^7.0.0",
     "kefir": "^3.7.3",
     "yargs": "^15.0.1"
+  },
+  "optionalDependencies": {
+    "chokidar": "^3.0.0"
   },
   "devDependencies": {
     "jest": "^24.1.0",


### PR DESCRIPTION
fix #29

BREAKING CHANGE: you must now explicitly install chokidar separately if you want to use watch mode.